### PR TITLE
[Fix] single gpu test bug

### DIFF
--- a/mmfewshot/detection/apis/test.py
+++ b/mmfewshot/detection/apis/test.py
@@ -69,14 +69,14 @@ def single_gpu_test(model: nn.Module,
                 if is_module_wrapper(model):
                     model.module.show_result(
                         img_show,
-                        result[i],
+                        result[j],
                         show=show,
                         out_file=out_file,
                         score_thr=show_score_thr)
                 else:
                     model.show_result(
                         img_show,
-                        result[i],
+                        result[j],
                         show=show,
                         out_file=out_file,
                         score_thr=show_score_thr)


### PR DESCRIPTION

## Motivation
When the output result needs to be saved and a single gpu test is used, an error will be reported. The solution is to change result[i] in the code to result[j]

## Modification
change result[i] in the code to result[j]

