### PR TITLE
Fix tabular printing of dataset information

### DIFF
--- a/mmfewshot/detection/datasets/base.py
+++ b/mmfewshot/detection/datasets/base.py
@@ -539,6 +539,8 @@ class BaseFewShotDataset(CustomDataset):
             if len(row_data) == 10:
                 table_data.append(row_data)
                 row_data = []
+        if len(row_data) != 0:
+            table_data.append(row_data)
 
         table = AsciiTable(table_data)
         result += table.table


### PR DESCRIPTION
## Motivation
When the length of the last row_data is less than 10 and greater than 0, the row_data will not be printed

## Modification
When the last row_data is not empty, add to table_data
