### PR TITLE
[Fix] Replace recommonmark with myst_parser

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'recommonmark',
+    'myst_parser',
     'sphinx.ext.autosectionlabel',
     'sphinx_copybutton',
     'sphinx_markdown_tables',

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -40,7 +40,7 @@ extensions = [
     'sphinx.ext.autodoc',
     'sphinx.ext.napoleon',
     'sphinx.ext.viewcode',
-    'recommonmark',
+    'myst_parser',
     'sphinx.ext.autosectionlabel',
     'sphinx_copybutton',
     'sphinx_markdown_tables',

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -1,6 +1,6 @@
 docutils==0.16.0
+myst-parser
 -e git+https://github.com/open-mmlab/pytorch_sphinx_theme.git#egg=pytorch_sphinx_theme
-recommonmark
 sphinx==4.0.2
 sphinx-copybutton
 sphinx_markdown_tables


### PR DESCRIPTION
## Motivation
Use myst_parser instead of remomonmark

## Modification
1. revise requirements/docs.txt
2. revise conf.py