### PR TITLE
[Fix] tools/classification/test.py bug

### DIFF
--- a/tools/classification/test.py
+++ b/tools/classification/test.py
@@ -92,7 +92,7 @@ def parse_args():
             'refers to https://mmclassification.readthedocs.io/en/latest/'
             'getting_started.html#inference-with-pretrained-models')
 
-    assert args.metrics or args.out, \
+    assert args.metrics or args.work_dir, \
         'Please specify at least one of output path and evaluation metrics.'
     return args
 


### PR DESCRIPTION
## Motivation
When run the following command according to [document](https://mmfewshot.readthedocs.io/en/latest/get_started.html), a error (AttributeError: 'Namespace' object has no attribute 'out') will be reported.
```shell
python ./tools/classification/test.py \
  configs/classification/baseline/cub/baseline_conv4_1xb64_cub_5way-1shot.py \
  checkpoints/SOME_CHECKPOINT.pth
```


## Modification
replace args.out with args.work_dir

