### PR TITLE
[Docs] Configure Myst-parser to parse anchor tag

### DIFF
--- a/docs/en/conf.py
+++ b/docs/en/conf.py
@@ -46,6 +46,10 @@ extensions = [
     'sphinx_markdown_tables',
 ]
 
+# Enable ::: for my_st
+myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 3
+
 autodoc_mock_imports = ['matplotlib', 'mmfewshot.version', 'mmcv.ops']
 
 # Add any paths that contain templates here, relative to this directory.

--- a/docs/zh_cn/conf.py
+++ b/docs/zh_cn/conf.py
@@ -46,6 +46,10 @@ extensions = [
     'sphinx_markdown_tables',
 ]
 
+# Enable ::: for my_st
+myst_enable_extensions = ['colon_fence']
+myst_heading_anchors = 3
+
 autodoc_mock_imports = ['matplotlib', 'mmfewshot.version', 'mmcv.ops']
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
By default, myst-parser did not parse links to anchor tags in markdown files, making these hyperlinks become raw texts in docs. This PR updates myst's configuration to enable this feature.

related PR https://github.com/open-mmlab/mmocr/pull/1012