### PR TITLE
Update optional.txt

### DIFF
--- a/requirements/optional.txt
+++ b/requirements/optional.txt
@@ -2,4 +2,4 @@ albumentations>=0.3.2
 cityscapesscripts
 imagecorruptions
 scipy
-sklearn
+scikit-learn


### PR DESCRIPTION
## Motivation

The `sklearn` PyPI package is deprecated, use `scikit-learn` rather than `sklearn`.

## Modification

replace 'sklearn' with 'scikit-learn'.
